### PR TITLE
Drawer inadvertently intercepts events.

### DIFF
--- a/src/Drawer/DrawerPane.js
+++ b/src/Drawer/DrawerPane.js
@@ -61,7 +61,7 @@ class DrawerPane extends React.PureComponent {
     const {
       className,
       children,
-      onClick
+      onClick,
     } = this.props;
 
     return (

--- a/src/Drawer/DrawerPane.js
+++ b/src/Drawer/DrawerPane.js
@@ -20,12 +20,6 @@ class DrawerPane extends React.PureComponent {
     this.handleTouchstart = this.handleTouchstart.bind(this);
   }
 
-  componentDidMount() {
-    const { onClick } = this.props;
-    this.native.addEventListener('click', onClick);
-    this.native.addEventListener('touchstart', this.handleTouchstart);
-  }
-
   componentWillReceiveProps(next) {
     const { animating, position } = this.props;
     if (animating !== next.animating && next.animating) {
@@ -35,12 +29,6 @@ class DrawerPane extends React.PureComponent {
     if (position !== next.position) {
       this.setTransformPosition(next.position);
     }
-  }
-
-  componentWillUnmount() {
-    const { onClick } = this.props;
-    this.removeEventListener('click', onClick);
-    this.removeEventListener('touchstart', this.handleTouchstart);
   }
 
   getTransformPropertyName() {
@@ -73,12 +61,15 @@ class DrawerPane extends React.PureComponent {
     const {
       className,
       children,
+      onClick
     } = this.props;
 
     return (
       <nav
         className={classnames(`${ROOT}__drawer`, className)}
         ref={(native) => { this.native = native; }}
+        onClick={onClick}
+        onTouchStart={this.handleTouchstart}
       >
         {children}
       </nav>

--- a/src/Drawer/DrawerShade.js
+++ b/src/Drawer/DrawerShade.js
@@ -17,13 +17,6 @@ class DrawerShade extends React.PureComponent {
     opacity: PropTypes.number,
   };
 
-  componentDidMount() {
-    const { onClick, onTouchmove, onTouchend } = this.props;
-    this.native.addEventListener('click', onClick);
-    this.native.addEventListener('touchmove', onTouchmove);
-    this.native.addEventListener('touchend', onTouchend);
-  }
-
   componentWillReceiveProps(next) {
     const { opacity } = this.props;
     if (opacity !== next.opacity && isSupportCssCustomProperties()) {
@@ -31,18 +24,14 @@ class DrawerShade extends React.PureComponent {
     }
   }
 
-  componentWillUnmount() {
-    const { onClick, onTouchmove, onTouchend } = this.props;
-    this.removeEventListener('click', onClick);
-    this.removeEventListener('touchmove', onTouchmove);
-    this.removeEventListener('touchend', onTouchend);
-  }
-
   render() {
     const {
       animating,
       className,
       children,
+      onClick,
+      onTouchend,
+      onTouchmove,
       open,
     } = this.props;
 
@@ -53,6 +42,9 @@ class DrawerShade extends React.PureComponent {
           [`${ROOT}--animating`]: animating,
         }, className)}
         ref={(native) => { this.native = native; }}
+        onClick={onClick}
+        onTouchEnd={onTouchend}
+        onTouchMove={onTouchmove}
       >
         {children}
       </aside>


### PR DESCRIPTION
React doesn't actually add event handlers directly to the target nodes. Instead it adds *all* listeners on the document element.

Manually adding listeners here intercepts any listeners on child elements e.g.:

```html
<Drawer>
    <DrawerContent>
        <a onClick={() => console.log('Never called')}>Broken Link</a>
    </DrawerContent>
</Drawer
```

React automatically handles correct bubbling of events from child to parent to grandparent so it is safe to use standard props mechanism.