### PR TITLE
Convert drawer to use a declarative pattern

### DIFF
--- a/src/Drawer/Temporary.js
+++ b/src/Drawer/Temporary.js
@@ -21,31 +21,13 @@ class Temporary extends Component {
 
   constructor(props) {
     super(props);
-    this.handleMenuToggle = this.handleMenuToggle.bind(this);
     this.handleShadeClick = this.handleShadeClick.bind(this);
     this.handleTransitionend = this.handleTransitionend.bind(this);
     this.handleTouchstart = this.handleTouchstart.bind(this);
     this.handleTouchmove = this.handleTouchmove.bind(this);
     this.handleTouchend = this.handleTouchend.bind(this);
-    this.open = this.open.bind(this);
     this.close = this.close.bind(this);
     this.state = {};
-  }
-
-  componentDidMount() {
-    const toggle = document.getElementById(this.props.target);
-    if (toggle) {
-      toggle.addEventListener('click', this.handleMenuToggle);
-    }
-  }
-
-  handleMenuToggle(event) {
-    event.stopPropagation();
-    if (this.state.open) {
-      this.close();
-    } else {
-      this.open();
-    }
   }
 
   handleShadeClick() {
@@ -53,7 +35,7 @@ class Temporary extends Component {
   }
 
   handleTouchstart({ pointerType, touches, pageX }, drawerWidth) {
-    if (!this.state.open) {
+    if (!this.props.open) {
       return;
     }
 
@@ -81,20 +63,18 @@ class Temporary extends Component {
     }
     const newPosition = this.calculateDrawerPosition();
     this.touchingSideNav = false;
+
+    this.setState({animating: true});
+
     // Did the user close the drawer by more than 50%?
     if (Math.abs(newPosition / this.drawerWidth) >= 0.5) {
       this.close();
-    } else {
-      this.open();
     }
   }
 
-  open() {
-    this.setState({ open: true, animating: true });
-  }
-
   close() {
-    this.setState({ open: false, animating: true });
+    const { onClose } = this.props;
+    (typeof onClose == "function") && onClose();
   }
 
   handleTransitionend() {
@@ -115,9 +95,15 @@ class Temporary extends Component {
     return null;
   }
 
+  componentWillReceiveProps (newProps) {
+    if (this.props.open != newProps.open) {
+      this.setState({animating: true});
+    }
+  }
+
   render() {
-    const { className, children, ...otherProps } = this.props;
-    const { open, animating } = this.state;
+    const { className, children, open, ...otherProps } = this.props;
+    const { animating } = this.state;
 
     const childs = React.Children.map(children, child =>
       React.cloneElement(child, { temporary: true }),

--- a/src/Drawer/Temporary.js
+++ b/src/Drawer/Temporary.js
@@ -7,7 +7,8 @@ class Temporary extends Component {
   static propTypes = {
     className: PropTypes.string,
     children: PropTypes.node,
-    target: PropTypes.string,
+    open: PropTypes.bool,
+    onClose: PropTypes.func,
     header: PropTypes.oneOf([PropTypes.string, PropTypes.node]),
   };
 
@@ -28,6 +29,12 @@ class Temporary extends Component {
     this.handleTouchend = this.handleTouchend.bind(this);
     this.close = this.close.bind(this);
     this.state = {};
+  }
+
+  componentWillReceiveProps(newProps) {
+    if (this.props.open !== newProps.open) {
+      this.setState({ animating: true });
+    }
   }
 
   handleShadeClick() {
@@ -64,7 +71,7 @@ class Temporary extends Component {
     const newPosition = this.calculateDrawerPosition();
     this.touchingSideNav = false;
 
-    this.setState({animating: true});
+    this.setState({ animating: true });
 
     // Did the user close the drawer by more than 50%?
     if (Math.abs(newPosition / this.drawerWidth) >= 0.5) {
@@ -74,7 +81,9 @@ class Temporary extends Component {
 
   close() {
     const { onClose } = this.props;
-    (typeof onClose == "function") && onClose();
+    if (typeof onClose === 'function') {
+      onClose();
+    }
   }
 
   handleTransitionend() {
@@ -93,12 +102,6 @@ class Temporary extends Component {
       return Math.max(0, 1 + (1 * (position / this.drawerWidth)));
     }
     return null;
-  }
-
-  componentWillReceiveProps (newProps) {
-    if (this.props.open != newProps.open) {
-      this.setState({animating: true});
-    }
   }
 
   render() {


### PR DESCRIPTION
Drawer is easier to reason about and control from global app state etc. by being declarative.

This pull request removes references to toggle button and adds an `open` prop.

Drawer can still closed by swiping through `onClose` prop. However the drawer is simply requesting to be closed. The parent component is still responsible for deciding whether or not the drawer is open.