### PR TITLE
Updated README

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ npm i --save react-mdc-web
 ### Default theme
 * Include CSS with default theme into HTML page
   ```html
-  <link rel="stylesheet" href="https://unpkg.com/material-components-web@latest/dist/material-components-web.min.css"> 
+  <link rel="stylesheet" href="https://unpkg.com/material-components-web@0.12.1/dist/material-components-web.min.css"> 
   ```
 * Or import it into JS/JSX file
   ```javascript
@@ -43,7 +43,7 @@ class MyComponent extends Component {
               Title goes here
             </CardTitle>
           </CardHeader>
-          <CardText> 
+          <CardText>
             Lorem ipsum dolor sit amet, sint adipiscing ius eu
           </CardText>
           <CardActions>


### PR DESCRIPTION
**What the change is:**
To state the correct version of material-components-web, since the 0.13.0 version introduced some issues (at least with grids).

**A little background:**
I noticed that today the grids on my app is all messed up, after doing some testing it seems `width: auto;` of `mdc-layout-grid__cell--span-3-desktop` was causing the issue. I did some research and there was a new version of material-components-web (v0.13.0) released. I reverted back to v0.12.1 and everything was working fine.

However, since the README stated @latest I was using the latest version without knowing it. Maybe it would be better to state a specific version of material-components-web to be used to prevent this kind of issues? 