### PR TITLE
feat(CardHorizontalBlock): new component

### DIFF
--- a/src/Card/CardHorizontalBlock.js
+++ b/src/Card/CardHorizontalBlock.js
@@ -1,0 +1,19 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+import classnames from 'classnames';
+
+const propTypes = {
+  className: PropTypes.string,
+  children: PropTypes.node,
+};
+
+const CardHorizontalBlock = ({ className, children, ...otherProps }) => (
+  <div
+    className={classnames('mdc-card__horizontal-block', className)}
+    {...otherProps}
+  >
+    {children}
+  </div>
+  );
+CardHorizontalBlock.propTypes = propTypes;
+export default CardHorizontalBlock;


### PR DESCRIPTION
Adds a CardHorizontalBlock component, that's meant to be simply used like the mdc-card__horizontal-block class.

For example:
```javascript
import React from 'react';
import Card from 'react-mdc-web/lib/Card/Card';
import CardTitle from 'react-mdc-web/lib/Card/CardTitle';
import CardActions from 'react-mdc-web/lib/Card/CardActions';
import CardHorizontalBlock from 'react-mdc-web/lib/Card/CardHorizontalBlock';

export default function HorizontalExample() {
  return (
    <Card style={{ width: '65%' }}>
      <CardHorizontalBlock>
        <div>
          <CardTitle>Horizontal</CardTitle>
          <CardActions><span>Action</span></CardActions>
        </div>
        <p>Consequat dolore irure ut sunt eu do consequat nulla duis duis anim officia.</p>
      </CardHorizontalBlock>
    </Card>
  );
}
```

Will be displayed like this:
![horizontal](https://user-images.githubusercontent.com/7149690/28521380-af22bccc-7073-11e7-8601-e5ddde5bb909.png)
