### PR TITLE
using "invalid" prop for textfields

### DIFF
--- a/docs/pages/components/text_field/_UseInvalidProp.jsx
+++ b/docs/pages/components/text_field/_UseInvalidProp.jsx
@@ -1,0 +1,32 @@
+import React, { PropTypes } from "react";
+import Textfield from "../../../../src/Textfield/Textfield";
+import { Grid, Cell } from "../../../../src/Grid";
+
+class UseInvalidProp extends React.PureComponent {
+  constructor(props) {
+    super(props);
+    this.state = { password: "" };
+  }
+
+  render() {
+    return (
+      <Grid>
+        <Cell col={12}>
+          <Textfield
+            floatingLabel="Password"
+            type="password"
+            useInvalidProp
+            invalid={true}
+            helptext="Your password is invalid."
+            helptextValidation
+            value={this.state.password}
+            onChange={({ target: { value: password } }) => {
+              this.setState({ password });
+            }}
+          />
+        </Cell>
+      </Grid>
+    );
+  }
+}
+export default UseInvalidProp;

--- a/docs/pages/components/text_field/_template.jsx
+++ b/docs/pages/components/text_field/_template.jsx
@@ -4,6 +4,7 @@ import FloatingLabel from './_FloatingLabel'
 import Helptext from './_Helptext'
 import HelptextPersistent from './_HelptextPersistent'
 import HelptextValidation from './_HelptextValidation'
+import UseInvalidProp from './_UseInvalidProp'
 import Multiline from './_Multiline'
 
 class Template extends React.PureComponent {
@@ -24,6 +25,9 @@ class Template extends React.PureComponent {
 
     const helptextValidation = document.getElementById("text-field-validation");
     ReactDOM.render(<HelptextValidation/>, helptextValidation);
+
+    const useInvalidProp = document.getElementById("text-field-invalidprop");
+    ReactDOM.render(<UseInvalidProp/>, useInvalidProp);
 
     const multiline = document.getElementById("text-field-multiline");
     ReactDOM.render(<Multiline/>, multiline);

--- a/docs/pages/components/text_field/index.md
+++ b/docs/pages/components/text_field/index.md
@@ -92,6 +92,26 @@ text-field-validation
 />
 ```
 
+### Use "invalid" Prop
+You can use the invalid prop to change validity status. This works if ```useInvalidProp```  is true.
+```react-snippet
+text-field-invalidprop
+```
+```jsx
+<Textfield
+  floatingLabel="Password"
+  type="password"
+  useInvalidProp
+  invalid={true}
+  helptext="Your password is invalid."
+  helptextValidation
+  value={this.state.password}
+  onChange={({ target: { value: password } }) => {
+    this.setState({ password });
+  }}
+/>
+```
+
 ### Multiline
 ```react-snippet
 text-field-multiline

--- a/src/Textfield/Textfield.js
+++ b/src/Textfield/Textfield.js
@@ -1,11 +1,12 @@
-import PropTypes from "prop-types";
-import React from "react";
-import Label from "./Label";
-import Input from "./Input";
-import Field from "./Field";
-import Helptext from "./Helptext";
+import PropTypes from 'prop-types';
+import React from 'react';
+import Label from './Label';
+import Input from './Input';
+import Field from './Field';
+import Helptext from './Helptext';
 
 class Textfield extends React.PureComponent {
+
   static propTypes = {
     className: PropTypes.string,
     disabled: PropTypes.bool,
@@ -13,15 +14,17 @@ class Textfield extends React.PureComponent {
     helptext: PropTypes.string,
     helptextPersistent: PropTypes.bool,
     helptextValidation: PropTypes.bool,
+    useInvalidProp: PropTypes.bool,
+    invalid: PropTypes.bool,
     id: PropTypes.string,
     multiline: PropTypes.bool,
     required: PropTypes.bool,
-    value: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-  };
+    value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  }
 
   constructor(props) {
     super(props);
-    this.state = {};
+    this.state = { };
   }
 
   onFocus() {
@@ -34,7 +37,8 @@ class Textfield extends React.PureComponent {
   }
 
   renderField() {
-    const { focus, invalid } = this.state;
+    const focus = this.state.focus;
+    let invalid = this.state.invalid;
     const {
       className,
       disabled,
@@ -50,8 +54,8 @@ class Textfield extends React.PureComponent {
       ...otherProps
     } = this.props;
     if (useInvalidProp) invalid = !!invalidProp;
-    const label = floatingLabel || "";
-    const customId = id || `textfield-${label.replace(/[^a-z0-9]/gi, "")}`;
+    const label = floatingLabel || '';
+    const customId = id || `textfield-${label.replace(/[^a-z0-9]/gi, '')}`;
     return (
       <Field
         className={className}
@@ -64,16 +68,16 @@ class Textfield extends React.PureComponent {
           disabled={disabled}
           id={customId}
           multiline={multiline}
-          onBlur={event => {
-            this.onBlur(event);
-          }}
-          onFocus={() => {
-            this.onFocus();
-          }}
+          onBlur={(event) => { this.onBlur(event); }}
+          onFocus={() => { this.onFocus(); }}
           value={value}
           {...otherProps}
         />
-        <Label focused={focus} id={customId} value={value}>
+        <Label
+          focused={focus}
+          id={customId}
+          value={value}
+        >
           {floatingLabel}
         </Label>
       </Field>
@@ -81,8 +85,14 @@ class Textfield extends React.PureComponent {
   }
 
   renderHelptext() {
-    const { focus, invalid } = this.state;
-    const { helptext, helptextPersistent, helptextValidation, useInvalidProp , invalid : invalidProp } = this.props;
+    const focus = this.state.focus;
+    let invalid = this.state.invalid;
+    const {
+      helptext,
+      helptextPersistent,
+      helptextValidation,
+      useInvalidProp,
+      invalid: invalidProp } = this.props;
     if (useInvalidProp) invalid = !!invalidProp;
     return (
       <Helptext
@@ -91,7 +101,7 @@ class Textfield extends React.PureComponent {
         helptextPersistent={helptextPersistent}
         helptextValidation={helptextValidation}
       >
-        {helptext}
+        { helptext }
       </Helptext>
     );
   }

--- a/src/Textfield/Textfield.js
+++ b/src/Textfield/Textfield.js
@@ -13,6 +13,8 @@ class Textfield extends React.PureComponent {
     helptext: PropTypes.string,
     helptextPersistent: PropTypes.bool,
     helptextValidation: PropTypes.bool,
+    useInvalidProp: PropTypes.bool,
+    invalid: PropTypes.bool,
     id: PropTypes.string,
     multiline: PropTypes.bool,
     required: PropTypes.bool,

--- a/src/Textfield/Textfield.js
+++ b/src/Textfield/Textfield.js
@@ -36,7 +36,7 @@ class Textfield extends React.PureComponent {
   }
 
   renderField() {
-    const { focus, invalid } = this.state;
+    var { focus, invalid } = this.state;
     const {
       className,
       disabled,
@@ -83,7 +83,7 @@ class Textfield extends React.PureComponent {
   }
 
   renderHelptext() {
-    const { focus, invalid } = this.state;
+    var { focus, invalid } = this.state;
     const { helptext, helptextPersistent, helptextValidation, useInvalidProp , invalid : invalidProp } = this.props;
     if (useInvalidProp) invalid = !!invalidProp;
     return (

--- a/src/Textfield/Textfield.js
+++ b/src/Textfield/Textfield.js
@@ -1,12 +1,11 @@
-import PropTypes from 'prop-types';
-import React from 'react';
-import Label from './Label';
-import Input from './Input';
-import Field from './Field';
-import Helptext from './Helptext';
+import PropTypes from "prop-types";
+import React from "react";
+import Label from "./Label";
+import Input from "./Input";
+import Field from "./Field";
+import Helptext from "./Helptext";
 
 class Textfield extends React.PureComponent {
-
   static propTypes = {
     className: PropTypes.string,
     disabled: PropTypes.bool,
@@ -17,12 +16,12 @@ class Textfield extends React.PureComponent {
     id: PropTypes.string,
     multiline: PropTypes.bool,
     required: PropTypes.bool,
-    value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
-  }
+    value: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  };
 
   constructor(props) {
     super(props);
-    this.state = { };
+    this.state = {};
   }
 
   onFocus() {
@@ -43,13 +42,16 @@ class Textfield extends React.PureComponent {
       helptext, // eslint-disable-line no-unused-vars
       helptextPersistent, // eslint-disable-line no-unused-vars
       helptextValidation, // eslint-disable-line no-unused-vars
+      useInvalidProp,
+      invalid: invalidProp,
       id,
       multiline,
       value, // eslint-disable-line no-unused-vars
       ...otherProps
     } = this.props;
-    const label = floatingLabel || '';
-    const customId = id || `textfield-${label.replace(/[^a-z0-9]/gi, '')}`;
+    if (useInvalidProp) invalid = !!invalidProp;
+    const label = floatingLabel || "";
+    const customId = id || `textfield-${label.replace(/[^a-z0-9]/gi, "")}`;
     return (
       <Field
         className={className}
@@ -62,16 +64,16 @@ class Textfield extends React.PureComponent {
           disabled={disabled}
           id={customId}
           multiline={multiline}
-          onBlur={(event) => { this.onBlur(event); }}
-          onFocus={() => { this.onFocus(); }}
+          onBlur={event => {
+            this.onBlur(event);
+          }}
+          onFocus={() => {
+            this.onFocus();
+          }}
           value={value}
           {...otherProps}
         />
-        <Label
-          focused={focus}
-          id={customId}
-          value={value}
-        >
+        <Label focused={focus} id={customId} value={value}>
           {floatingLabel}
         </Label>
       </Field>
@@ -80,7 +82,8 @@ class Textfield extends React.PureComponent {
 
   renderHelptext() {
     const { focus, invalid } = this.state;
-    const { helptext, helptextPersistent, helptextValidation } = this.props;
+    const { helptext, helptextPersistent, helptextValidation, useInvalidProp , invalid : invalidProp } = this.props;
+    if (useInvalidProp) invalid = !!invalidProp;
     return (
       <Helptext
         focused={focus}
@@ -88,7 +91,7 @@ class Textfield extends React.PureComponent {
         helptextPersistent={helptextPersistent}
         helptextValidation={helptextValidation}
       >
-        { helptext }
+        {helptext}
       </Helptext>
     );
   }

--- a/src/Textfield/Textfield.js
+++ b/src/Textfield/Textfield.js
@@ -37,12 +37,8 @@ class Textfield extends React.PureComponent {
   }
 
   renderField() {
-<<<<<<< HEAD
     const focus = this.state.focus;
     let invalid = this.state.invalid;
-=======
-    var { focus, invalid } = this.state;
->>>>>>> e34fc049124dbc0fb71193190840572818ae3032
     const {
       className,
       disabled,
@@ -89,7 +85,6 @@ class Textfield extends React.PureComponent {
   }
 
   renderHelptext() {
-<<<<<<< HEAD
     const focus = this.state.focus;
     let invalid = this.state.invalid;
     const {
@@ -98,10 +93,6 @@ class Textfield extends React.PureComponent {
       helptextValidation,
       useInvalidProp,
       invalid: invalidProp } = this.props;
-=======
-    var { focus, invalid } = this.state;
-    const { helptext, helptextPersistent, helptextValidation, useInvalidProp , invalid : invalidProp } = this.props;
->>>>>>> e34fc049124dbc0fb71193190840572818ae3032
     if (useInvalidProp) invalid = !!invalidProp;
     return (
       <Helptext


### PR DESCRIPTION
I added some code so that textfields can be explicitly made invalid by using a "invalid" prop. This must be first enabled by the "useInvalidProp" prop.

I've also updated the docs to add description for this feature.

I haven't actually tested it myself since i coudn't get node-sass working on my pc, and there's probably some linting issues, but I don't think it has any big problems. What do you think?