### PR TITLE
Upgrade to MDC 0.21.0

### DIFF
--- a/docs/css/main.css
+++ b/docs/css/main.css
@@ -65,3 +65,14 @@ code[class*="language-"]{
   font-size: 0.85rem;
 }
 
+/* Needed to make demo buttons pick up the primary color, since the concept of primary button is
+   removed in mdc version 0.21 */
+.mdc-button--raised {
+  background-color: var(--mdc-theme-primary, #3f51b5) !important;
+  color: var(--mdc-theme-text-primary-on-primary,#fff) !important;  
+}
+
+.mdc-snackbar__action-button {
+  color: var(--mdc-theme-accent,#ff4081) !important;
+  background-color: unset !important;
+}

--- a/docs/pages/components/button/_Counter.jsx
+++ b/docs/pages/components/button/_Counter.jsx
@@ -12,7 +12,6 @@ class Counter extends React.PureComponent {
       <div style={{margin: '16px 0'}}>
         <Button 
           raised 
-          primary
           onClick={() => {
             let { counter } = this.state;
             counter ++;

--- a/docs/pages/components/button/_template.jsx
+++ b/docs/pages/components/button/_template.jsx
@@ -23,9 +23,7 @@ class Buttons extends React.PureComponent {
       <div>
         <Button style={{margin:'16px'}} raised={isRaised}>Default</Button>
         <Button style={{margin:'16px'}} raised={isRaised} dense>Dense</Button>
-        <Button style={{margin:'16px'}} raised={isRaised} primary>Primary</Button>
         <Button style={{margin:'16px'}} raised={isRaised} compact>Compact</Button>
-        <Button style={{margin:'16px'}} raised={isRaised} accent>Accent</Button>
       </div>
     )
   }

--- a/docs/pages/components/button/index.md
+++ b/docs/pages/components/button/index.md
@@ -10,9 +10,7 @@ flat-buttons
 ```jsx
 <Button>Default</Button>
 <Button dense>Dense</Button>
-<Button primary>Primary</Button>
 <Button compact>Compact</Button>
-<Button accent>Accent</Button>
 ```
 ### Raised buttons
 ```react-snippet
@@ -21,9 +19,7 @@ raised-buttons
 ```jsx
 <Button raised>Default</Button>
 <Button raised dense>Dense</Button>
-<Button raised primary>Primary</Button>
 <Button raised compact>Compact</Button>
-<Button raised accent>Accent</Button>
 ```
 
 ### Handle click
@@ -33,7 +29,6 @@ click-button
 ```jsx
 <Button
   raised 
-  primary
   onClick={()=>{
     let { counter } = this.state;
     counter ++;

--- a/docs/pages/components/card/_template.jsx
+++ b/docs/pages/components/card/_template.jsx
@@ -34,8 +34,8 @@ class Template extends React.PureComponent {
           Lorem ipsum dolor sit amet, consectetur adipisicing elit.
         </CardText>
         <CardActions>
-          <Button compact primary>action 1</Button>
-          <Button compact >action 2</Button>
+          <Button compact>action 1</Button>
+          <Button compact>action 2</Button>
         </CardActions>
       </Card>
     )
@@ -58,8 +58,8 @@ class Template extends React.PureComponent {
           Lorem ipsum dolor sit amet, consectetur adipisicing elit.
         </CardText>
         <CardActions>
-          <Button compact primary>action 1</Button>
-          <Button compact >action 2</Button>
+          <Button compact>action 1</Button>
+          <Button compact>action 2</Button>
         </CardActions>
       </Card>
     )

--- a/docs/pages/components/card/index.md
+++ b/docs/pages/components/card/index.md
@@ -16,7 +16,7 @@ text-card
     Lorem ipsum dolor sit amet, consectetur adipisicing elit.
   </CardText>
   <CardActions>
-    <Button compact primary>action 1</Button>
+    <Button compact >action 1</Button>
     <Button compact >action 2</Button>
   </CardActions>
 </Card>
@@ -41,7 +41,7 @@ media-card
     Lorem ipsum dolor sit amet, consectetur adipisicing elit.
   </CardText>
   <CardActions>
-    <Button compact primary>action 1</Button>
+    <Button compact >action 1</Button>
     <Button compact >action 2</Button>
   </CardActions>
 </Card>

--- a/docs/pages/components/dialog/_Scrollable.jsx
+++ b/docs/pages/components/dialog/_Scrollable.jsx
@@ -19,7 +19,6 @@ class Standard extends React.PureComponent {
     return (
       <div>
         <Button
-          primary
           raised
           onClick={()=> { this.setState({isOpen: true}) }}
         >

--- a/docs/pages/components/dialog/_Standard.jsx
+++ b/docs/pages/components/dialog/_Standard.jsx
@@ -17,7 +17,6 @@ class Standard extends React.PureComponent {
     return (
       <div>
         <Button
-          primary
           raised
           onClick={()=> { this.setState({isOpen: true}) }}
         >

--- a/docs/pages/components/dialog/index.md
+++ b/docs/pages/components/dialog/index.md
@@ -8,7 +8,6 @@ simple
 ```
 ```jsx
 <Button
-  primary
   raised
   onClick={()=> { this.setState({isOpen: true}) }}
 >
@@ -36,7 +35,6 @@ scrollable
 ```
 ```jsx
 <Button
-  primary
   raised
   onClick={()=> { this.setState({isOpen: true}) }}
 >

--- a/docs/pages/components/drawer/_Temporary.jsx
+++ b/docs/pages/components/drawer/_Temporary.jsx
@@ -19,7 +19,6 @@ class Permanent extends React.PureComponent {
     return (
       <div>
         <Button 
-          primary
           raised 
           onClick={()=> { this.setState({isOpen: !this.state.isOpen}) }}
         >

--- a/docs/pages/components/drawer/index.md
+++ b/docs/pages/components/drawer/index.md
@@ -24,7 +24,6 @@ temporary
 ```
 ```jsx
 <Button 
-  primary
   raised 
   onClick={()=> { this.setState({isOpen: !this.state.isOpen}) }}
 >

--- a/docs/pages/components/elevation/_Default.jsx
+++ b/docs/pages/components/elevation/_Default.jsx
@@ -29,7 +29,6 @@ class Default extends React.PureComponent {
         <div>
           <Button 
             raised
-            primary
             onClick={() => {
               this.setState({level: level===0?4:0});
             }}

--- a/docs/pages/components/fab/_template.jsx
+++ b/docs/pages/components/fab/_template.jsx
@@ -19,8 +19,6 @@ class Template extends React.PureComponent {
       <div>
         <Fab style={{margin: '16px'}}><Icon name='create'/></Fab>
         <Fab style={{margin: '16px'}} mini><Icon name='create'/></Fab>
-        <Fab style={{margin: '16px'}} plain><Icon name='create'/></Fab>
-        <Fab style={{margin: '16px'}} plain mini><Icon name='create'/></Fab>
       </div>
     )
   }

--- a/docs/pages/components/fab/index.md
+++ b/docs/pages/components/fab/index.md
@@ -11,11 +11,4 @@ fabs
 
 {/* Mini */}
 <Fab mini><Icon name='create'/></Fab>
-
-{/* Plain */}
-<Fab plain><Icon name='create'/></Fab>
-
-{/* Plain mini */}
-<Fab plain mini><Icon name='create'/></Fab>
-
 ```

--- a/docs/pages/components/menu/_Default.jsx
+++ b/docs/pages/components/menu/_Default.jsx
@@ -13,7 +13,6 @@ class Default extends React.PureComponent {
     return (
       <div>
         <Button
-          primary
           raised
           onClick={()=>{this.setState({open:true})}}
         >

--- a/docs/pages/components/snackbar/_Multiline.jsx
+++ b/docs/pages/components/snackbar/_Multiline.jsx
@@ -15,7 +15,6 @@ class Multiline extends React.PureComponent {
       <div>
         <Button 
           raised
-          primary
           onClick={()=> { this.setState({snackbar: true}) }}
         >Open snackbar</Button>
         <Snackbar

--- a/docs/pages/components/snackbar/_MultilineBottomAction.jsx
+++ b/docs/pages/components/snackbar/_MultilineBottomAction.jsx
@@ -15,7 +15,6 @@ class MultilineBottomAction extends React.PureComponent {
       <div>
         <Button 
           raised
-          primary
           onClick={()=> { this.setState({snackbar: true}) }}
         >Open snackbar</Button>
         <Snackbar

--- a/docs/pages/components/snackbar/_Singleline.jsx
+++ b/docs/pages/components/snackbar/_Singleline.jsx
@@ -15,7 +15,6 @@ class Singleline extends React.PureComponent {
       <div>
         <Button 
           raised
-          primary
           onClick={()=> { this.setState({snackbar: true}) }}
         >Open snackbar</Button>
         <Snackbar

--- a/docs/pages/components/snackbar/_SinglelineAction.jsx
+++ b/docs/pages/components/snackbar/_SinglelineAction.jsx
@@ -15,7 +15,6 @@ class SinglelineAction extends React.PureComponent {
       <div>
         <Button 
           raised
-          primary
           onClick={()=> { this.setState({snackbar: true}) }}
         >Open snackbar</Button>
         <span 

--- a/docs/pages/components/snackbar/_SinglelineTimeout.jsx
+++ b/docs/pages/components/snackbar/_SinglelineTimeout.jsx
@@ -15,7 +15,6 @@ class SinglelineTimeout extends React.PureComponent {
       <div>
         <Button 
           raised
-          primary
           onClick={()=> { this.setState({snackbar: true}) }}
         >Open snackbar</Button>
         <Snackbar

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
   },
   "dependencies": {
     "classnames": "^2.2.5",
-    "material-components-web": "^0.19.0",
+    "material-components-web": "^0.21.0",
     "prop-types": "^15.5.10"
   }
 }

--- a/src/Button/Button.js
+++ b/src/Button/Button.js
@@ -3,31 +3,25 @@ import React from 'react';
 import classnames from 'classnames';
 
 const propTypes = {
-  accent: PropTypes.bool,
   children: PropTypes.node,
   className: PropTypes.string,
   compact: PropTypes.bool,
   dense: PropTypes.bool,
-  primary: PropTypes.bool,
   raised: PropTypes.bool,
 };
 
 const Button = ({
-  accent,
   children,
   className,
   compact,
   dense,
-  primary,
   raised,
   ...otherProps
 }) => {
   const classes = classnames(
     'mdc-button', {
-      'mdc-button--accent': accent,
       'mdc-button--compact': compact,
       'mdc-button--dense': dense,
-      'mdc-button--primary': primary,
       'mdc-button--raised': raised,
     }, className);
   return (

--- a/src/Fab/Fab.js
+++ b/src/Fab/Fab.js
@@ -9,19 +9,16 @@ const propTypes = {
   className: PropTypes.string,
   children: PropTypes.node,
   mini: PropTypes.bool,
-  plain: PropTypes.bool,
 };
 
 const Fab = ({
   className,
   mini,
-  plain,
   ...otherProps
 }) => {
   const classes = classnames(
     ROOT, {
       [`${ROOT}--mini`]: mini,
-      [`${ROOT}--plain`]: plain,
     }, className);
 
   const children = Children.map(otherProps.children, (child) => {

--- a/src/Snackbar/Snackbar.js
+++ b/src/Snackbar/Snackbar.js
@@ -1,7 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import classnames from 'classnames';
-import Button from '../Button/Button';
 
 const ROOT = 'mdc-snackbar';
 const ACTIVE = `${ROOT}--active`;
@@ -88,12 +87,13 @@ class Snackbar extends React.PureComponent {
           aria-hidden={!onClick || !action || !open}
           className={ACTION_WRAPPER}
         >
-          <Button
+          <button
+            type="button"
             className={ACTION_BUTTON}
             onClick={(event) => { if (onClick) onClick(event); }}
           >
             {action}
-          </Button>
+          </button>
         </div>
       </div>
     );


### PR DESCRIPTION
Essentially take care of all [breaking changes introduced since 0.19.0](https://github.com/material-components/material-components-web/blob/master/CHANGELOG.md#breaking-changes-1)
Note that there are no breaking changes in 0.20.0 that affects react-mdc-web.

- Remove the `primary` and `accent` properties on Button, since MDC
  has removed that concept. Also removed all usages of `primary`
  from the demo pages. Also update main.css to default raised button
  color to match the demo's primary color.
- Remove the `plain` property from Fab, since MDC has removed that concept.
- Updated the snackbar demo to accommodate changes in button colors.