### PR TITLE
Support all toolbar modes

### DIFF
--- a/docs/components/Content/Content.js
+++ b/docs/components/Content/Content.js
@@ -7,8 +7,10 @@ const propTypes = {
   children: PropTypes.node,
 };
 
-const AppContent = ({ children }) => (
-  <Content 
+const AppContent = ({ fixed, children, className }) => (
+  <Content
+    fixed={fixed}
+    className={className}
     style={{
       display: "flex",
       boxSizing: "border-box",

--- a/docs/components/Toolbar/Toolbar.js
+++ b/docs/components/Toolbar/Toolbar.js
@@ -7,51 +7,67 @@ import { Link } from 'react-router'
 import { prefixLink } from 'gatsby-helpers'
 import Logo from '../Logo';
 
-const propTypes = {
-  className: PropTypes.string,
-  title: PropTypes.string,
-};
 
-const AppToolbar = ({ className, title, ...otherProps }) => (
-  <Toolbar
-    fixed
-    style = {{
-      paddingLeft: '16px',
-      paddingRight: '16px',
-      zIndex: 2,
-    }}
-  >
-    <ToolbarRow>
-      <ToolbarSection 
-        align="start"
+export default class AppToolbar extends React.Component {
+
+  static propTypes = {
+    className: PropTypes.string,
+    title: PropTypes.string,
+    toolbarMode: PropTypes.object
+  }
+
+  render() {
+    const { className, title, toolbarMode, ...otherProps } = this.props;
+
+    return <Toolbar
+        fixed = {toolbarMode.fixed}
+        waterfall = {toolbarMode.waterfall}
+        flexible = {toolbarMode.flexible}
+        fixedLastRowOnly = {toolbarMode.fixedLastRowOnly}
+        flexibleDefaultBehavior = {toolbarMode.flexibleDefaultBehavior}
+        style = {{
+          paddingLeft: '16px',
+          paddingRight: '16px',
+        }}
+        ref={(node) => { this.node = node; }}
       >
-        <Logo/>
-        <ToolbarTitle style={{lineHeight: "36px"}}>
-          <Link
-            to={prefixLink('/')}
-            style={{ color: colors.fg }}
-            className="site-title"
+        <ToolbarRow>
+          <ToolbarSection
+            align="start"
           >
-            {title}
-          </Link>
-        </ToolbarTitle>
-      </ToolbarSection>
-      <ToolbarSection 
-        align="end"
-      >
-        <a
-          style={{
-            color: colors.fg,
-            textDecoration: 'none',
-            lineHeight: '36px',
-          }}
-          href="https://github.com/kradio3/react-mdc-web"
-        >
-          Github
-        </a>
-      </ToolbarSection>
-    </ToolbarRow>
-  </Toolbar>
-);
-AppToolbar.propTypes = propTypes;
-export default AppToolbar;
+            <Logo/>
+            <ToolbarTitle style={{lineHeight: "36px"}}>
+              <Link
+                to={prefixLink('/')}
+                style={{ color: colors.fg }}
+                className="site-title"
+              >
+                {title}
+              </Link>
+            </ToolbarTitle>
+          </ToolbarSection>
+          <ToolbarSection
+            align="end"
+          >
+            <a
+              style={{
+                color: colors.fg,
+                textDecoration: 'none',
+                lineHeight: '36px',
+              }}
+              href="https://github.com/kradio3/react-mdc-web"
+            >
+              Github
+            </a>
+          </ToolbarSection>
+        </ToolbarRow>
+        {toolbarMode.fixedLastRowOnly &&
+          <ToolbarRow>
+            <ToolbarSection>
+              The last row
+            </ToolbarSection>
+          </ToolbarRow>
+        }
+    </Toolbar>
+  }
+}

--- a/docs/pages/_template.jsx
+++ b/docs/pages/_template.jsx
@@ -23,12 +23,69 @@ import '../../node_modules/material-components-web/dist/material-components-web.
 import 'prismjs/themes/prism-okaidia.css'
 import 'css/main.css'
 
-module.exports = React.createClass({
-  propTypes () {
-    return {
-      children: React.PropTypes.object,
+export default class Main extends React.Component {
+  static propTypes = {
+    children: React.PropTypes.object,
+  }
+
+  componentWillMount() {
+    // See the counterpart that sets the cookie in ToolbarBase
+    const mode = document.cookie.replace(/(?:(?:^|.*;\s*)toolbar-mode\s*\=\s*([^;]*).*$)|^.*$/, "$1");
+
+    var toolbarMode = {}
+    if (mode == 'normal') {
+      toolbarMode = {
+        fixed: false,
+        waterfall: false,
+        flexible: false,
+        flexibleDefaultBehavior: false,
+        fixedLastRowOnly: false
+      };
+    } else if (mode == 'waterfall-flexible') {
+      toolbarMode = {
+        fixed: true,
+        waterfall: true,
+        flexible: true,
+        flexibleDefaultBehavior: true,
+        fixedLastRowOnly: false
+      };
+    } else if (mode == 'waterfall-flexible-fixedLastRowOnly') {
+      toolbarMode = {
+        fixed: true,
+        waterfall: true,
+        flexible: true,
+        flexibleDefaultBehavior: true,
+        fixedLastRowOnly: true
+      };
+    } else if (mode == 'waterfall') {
+      toolbarMode = {
+        fixed: true,
+        waterfall: true,
+        flexible: false,
+        flexibleDefaultBehavior: false,
+        fixedLastRowOnly: false
+      };
+    } else if (mode == 'flexible') {
+      toolbarMode = {
+        fixed: false,
+        waterfall: false,
+        flexible: true,
+        flexibleDefaultBehavior: false,
+        fixedLastRowOnly: false
+      };
+    } else { // default is fixed
+      toolbarMode = {
+        fixed: true,
+        waterfall: false,
+        flexible: false,
+        flexibleDefaultBehavior: false,
+        fixedLastRowOnly: false
+      };
     }
-  },
+
+    this.setState({toolbarMode: toolbarMode});
+  }
+
   render () {
     const isIntroductionActive = this.props.location.pathname===prefixLink('/');
     const isThemingActive = this.props.location.pathname===prefixLink('/theming/');
@@ -48,8 +105,9 @@ module.exports = React.createClass({
       <Layout>
         <Toolbar 
           title={config.siteTitle}
+          toolbarMode={this.state.toolbarMode}
         />
-        <Content>
+        <Content fixed={this.state.toolbarMode.fixed}>
           <Drawer
             permanent
             style={{height: 'inherit', minHeight: '100%'}}
@@ -81,5 +139,5 @@ module.exports = React.createClass({
         </Content>
       </Layout>
     )
-  },
-})
+  }
+}

--- a/docs/pages/components/toolbar/_Fixed.jsx
+++ b/docs/pages/components/toolbar/_Fixed.jsx
@@ -1,55 +1,7 @@
-import React, {PropTypes} from 'react'
-import ReactDOMServer from 'react-dom/server'
-import Toolbar from '../../../../src/Toolbar/Toolbar'
-import ToolbarSection from '../../../../src/Toolbar/ToolbarSection'
-import ToolbarTitle from '../../../../src/Toolbar/ToolbarTitle'
-import Content from '../../../../src/Content/Content'
+import ToolbarBase from './_ToolbarBase'
 
-class Fixed extends React.PureComponent {
-
-  renderToolbar() {
-    return (
-      <html>
-        <head>
-          <link
-            rel="stylesheet"
-            href="https://unpkg.com/material-components-web@0.5.0/dist/material-components-web.min.css"/>
-          </head>
-          <body className= "mdc-typography">
-          <div style={{height: '300px', position: 'relative', overflow: 'auto'}}>
-            <Toolbar fixed>
-              <ToolbarSection align="start">
-                <ToolbarTitle>Title</ToolbarTitle>
-              </ToolbarSection>
-            </Toolbar>
-            <Content 
-              className="mdc-toolbar__fixed-adjust mdc-toolbar-fixed-adjust"
-            >
-              Content
-            </Content> 
-          </div>
-          </body>
-        </html>
-        )
-        }
-
-        render () {
-          return (
-              <iframe
-                style={{border: '1px solid #e4e4e4'}}
-                width="500px"
-                height="300px"
-                ref={(iframe)=>{
-                  let doc = iframe.contentDocument;
-                  doc.open;
-                  let toolbar = ReactDOMServer.renderToString(this.renderToolbar());
-
-                  doc.write(toolbar);
-                  doc.close();
-                }}
-              >
-              </iframe>
-          )
-        }
-        }
-        export default Fixed;
+export default class Fixed extends ToolbarBase {
+  constructor() {
+    super('fixed');
+  }
+}

--- a/docs/pages/components/toolbar/_Flexible.jsx
+++ b/docs/pages/components/toolbar/_Flexible.jsx
@@ -1,0 +1,7 @@
+import ToolbarBase from './_ToolbarBase'
+
+export default class Flexible extends ToolbarBase {
+  constructor() {
+    super('flexible');
+  }
+}

--- a/docs/pages/components/toolbar/_Normal.jsx
+++ b/docs/pages/components/toolbar/_Normal.jsx
@@ -1,24 +1,7 @@
-import React, {PropTypes} from 'react'
-import Toolbar from '../../../../src/Toolbar/Toolbar'
-import ToolbarSection from '../../../../src/Toolbar/ToolbarSection'
-import ToolbarTitle from '../../../../src/Toolbar/ToolbarTitle'
-import ToolbarRow from '../../../../src/Toolbar/ToolbarRow'
+import ToolbarBase from './_ToolbarBase'
 
-class Normal extends React.PureComponent {
-
-  render () {
-    return (
-      <div style={{height: '300px', width: '500px', position: 'relative', overflow: 'auto'}}>
-        <Toolbar>
-          <ToolbarRow>
-            <ToolbarSection align="start">
-              <ToolbarTitle>Title</ToolbarTitle>
-            </ToolbarSection>
-          </ToolbarRow>
-        </Toolbar>
-        <div style={{height: '300px'}}>Content</div> 
-      </div>
-    )
+export default class Normal extends ToolbarBase {
+  constructor() {
+    super('normal');
   }
 }
-export default Normal;

--- a/docs/pages/components/toolbar/_ToolbarBase.jsx
+++ b/docs/pages/components/toolbar/_ToolbarBase.jsx
@@ -1,0 +1,27 @@
+import React, {PropTypes} from 'react'
+
+import Button from '../../../../src/Button/Button'
+
+export default class ToolbarBase extends React.PureComponent {
+  constructor(mode) {
+    super();
+    this.mode = mode;
+  }
+
+  activate() {
+    // If we just rely on changing props for the current toolbar, MDC doesn't
+    // updated the toolbar correctly, so we need to force a reload after
+    // setting a cookie that indicate the toolbar mode and the toolbar picking
+    // up that cookie before the first render.
+    // See the counterpart that uses this cookie in pages/_template.jsx
+    document.cookie = `toolbar-mode=${this.mode}`;
+    window.scroll(0,0);
+    location.reload();
+  }
+
+  render () {
+    return (
+      <Button raised={true} onClick={() => this.activate()}>Set toolbar to this mode</Button>
+    )
+  }
+}

--- a/docs/pages/components/toolbar/_Waterfall.jsx
+++ b/docs/pages/components/toolbar/_Waterfall.jsx
@@ -1,0 +1,7 @@
+import ToolbarBase from './_ToolbarBase'
+
+export default class Waterfall extends ToolbarBase {
+  constructor() {
+    super('waterfall');
+  }
+}

--- a/docs/pages/components/toolbar/_WaterfallFixedLastRowOnly.jsx
+++ b/docs/pages/components/toolbar/_WaterfallFixedLastRowOnly.jsx
@@ -1,0 +1,7 @@
+import ToolbarBase from './_ToolbarBase'
+
+export default class WaterfallFixedLastRowOnly extends ToolbarBase {
+  constructor() {
+    super('waterfall-flexible-fixedLastRowOnly');
+  }
+}

--- a/docs/pages/components/toolbar/_WaterfallFlexible.jsx
+++ b/docs/pages/components/toolbar/_WaterfallFlexible.jsx
@@ -1,0 +1,7 @@
+import ToolbarBase from './_ToolbarBase'
+
+export default class WaterfallFlexible extends ToolbarBase {
+  constructor() {
+    super('waterfall-flexible');
+  }
+}

--- a/docs/pages/components/toolbar/_template.jsx
+++ b/docs/pages/components/toolbar/_template.jsx
@@ -3,6 +3,10 @@ import ReactDOM from 'react-dom'
 import Normal from './_Normal'
 import Fixed from './_Fixed'
 import Sections from './_Sections'
+import Waterfall from './_Waterfall'
+import Flexible from './_Flexible'
+import WaterfallFlexible from './_WaterfallFlexible'
+import WaterfallFixedLastRowOnly from './_WaterfallFixedLastRowOnly'
 
 class Template extends React.PureComponent {
 
@@ -16,6 +20,18 @@ class Template extends React.PureComponent {
 
     const fixedContainer = document.getElementById("fixed-toolbar");
     ReactDOM.render(<Fixed/>, fixedContainer);
+
+    const waterfallContainer = document.getElementById("waterfall-toolbar");
+    ReactDOM.render(<Waterfall/>, waterfallContainer);
+
+    const flexibleContainer = document.getElementById("flexible-toolbar");
+    ReactDOM.render(<Flexible/>, flexibleContainer);
+
+    const waterfallFlexibleContainer = document.getElementById("waterfall-flexible-toolbar");
+    ReactDOM.render(<WaterfallFlexible/>, waterfallFlexibleContainer);
+
+    const waterfallFixedLastRowOnlyContainer = document.getElementById("waterfall-fixed_last_row_only-toolbar");
+    ReactDOM.render(<WaterfallFixedLastRowOnly/>, waterfallFixedLastRowOnlyContainer);
 
     const sectionsContainer = document.getElementById("sections");
     ReactDOM.render(<Sections/>, sectionsContainer);

--- a/docs/pages/components/toolbar/index.md
+++ b/docs/pages/components/toolbar/index.md
@@ -16,31 +16,6 @@ normal-toolbar
 </Toolbar>
 ```
 
-### Fixed toolbar
-```react-snippet
-fixed-toolbar
-```
-```jsx
-<Toolbar fixed>
-  <ToolbarRow>
-    <ToolbarSection align="start">
-      <ToolbarTitle>Title</ToolbarTitle>
-    </ToolbarSection>
-  </ToolbarRow>
-</Toolbar>
-
-{/* Adjust top margin for fixed toolbar */}
-<Content>
-  ...
-</Content>
-```
-``` Content ``` will produce the ```<main>``` tag by default, but you can override this behavior with property ```component```
-```jsx
-<Content component="div">
-  ...
-</Content>
-```
-
 ### Sections
 ```react-snippet
 sections
@@ -60,3 +35,95 @@ sections
     </ToolbarSection>
   </ToolbarRow>
 </Toolbar>
+```
+
+### Fixed toolbar
+```react-snippet
+fixed-toolbar
+```
+```jsx
+<Toolbar fixed>
+  <ToolbarRow>
+    <ToolbarSection align="start">
+      <ToolbarTitle>Title</ToolbarTitle>
+    </ToolbarSection>
+  </ToolbarRow>
+</Toolbar>
+
+<Content fixed>
+  ...
+</Content>
+```
+``` Content ``` will produce the ```<main>``` tag by default, but you can override this behavior with property ```component```
+```jsx
+<Content component="div">
+  ...
+</Content>
+```
+For fixed toolbars, set the ```fixed``` property so that the top margin is set appropriately based on the toolbar.
+```jsx
+<Content fixed>
+  ...
+</Content>
+```
+
+### Waterfall toolbar
+```react-snippet
+waterfall-toolbar
+```
+```jsx
+<Toolbar fixed waterfall>
+  <ToolbarRow>
+    <ToolbarSection align="start">
+      <ToolbarTitle>Title</ToolbarTitle>
+    </ToolbarSection>
+  </ToolbarRow>
+</Toolbar>
+```
+
+### Flexible toolar
+```react-snippet
+flexible-toolbar
+```
+```jsx
+<Toolbar flexible>
+  <ToolbarRow>
+    <ToolbarSection align="start">
+      <ToolbarTitle>Title</ToolbarTitle>
+    </ToolbarSection>
+  </ToolbarRow>
+</Toolbar>
+```
+
+### Waterfall flexible toolbar
+```react-snippet
+waterfall-flexible-toolbar
+```
+```jsx
+<Toolbar fixed waterfall flexible>
+  <ToolbarRow>
+    <ToolbarSection align="start">
+      <ToolbarTitle>Title</ToolbarTitle>
+    </ToolbarSection>
+  </ToolbarRow>
+</Toolbar>
+```
+
+### Waterfall toolbar with fixed last row
+```react-snippet
+waterfall-fixed_last_row_only-toolbar
+```
+```jsx
+<Toolbar fixed waterfall flexible fixedLastRowOnly>
+  <ToolbarRow>
+    <ToolbarSection align="start">
+      <ToolbarTitle>Title</ToolbarTitle>
+    </ToolbarSection>
+  </ToolbarRow>
+  <ToolbarRow>
+    <ToolbarSection align="start">
+      The last row
+    </ToolbarSection>
+  </ToolbarRow>
+</Toolbar>
+```

--- a/src/Content/Content.js
+++ b/src/Content/Content.js
@@ -2,7 +2,10 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import classnames from 'classnames';
 
+const FIXED_ADJUST = 'mdc-toolbar-fixed-adjust';
+
 const propTypes = {
+  fixed: PropTypes.bool,
   children: PropTypes.node,
   className: PropTypes.string,
   component: PropTypes.string,
@@ -13,12 +16,16 @@ const defaultProps = {
 };
 
 const Content = ({
+  fixed,
   className,
   children,
   component,
   ...otherProps
 }) => {
-  const classes = classnames('mdc-content', className);
+  const classes = classnames('mdc-content', {
+    [FIXED_ADJUST]: fixed,
+  }, className);
+
   return React.createElement(component, {
     className: classes,
     ...otherProps,

--- a/src/Toolbar/Toolbar.js
+++ b/src/Toolbar/Toolbar.js
@@ -2,9 +2,14 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import classnames from 'classnames';
 
+import { MDCToolbar } from '@material/toolbar/dist/mdc.toolbar';
+
 const ROOT = 'mdc-toolbar';
 const FIXED = `${ROOT}--fixed`;
-const ADJUST = `${ROOT}-fixed-adjust`;
+const WATERFALL = `${ROOT}--waterfall`;
+const FIXED_LAST_ROW_ONLY = `${ROOT}--fixed-lastrow-only`;
+const FLEXIBLE = `${ROOT}--flexible`;
+const FLEXIBLE_DEFAULT_BEHAVIOR = `${ROOT}--flexible-default-behavior`;
 
 class Toolbar extends React.PureComponent {
 
@@ -12,23 +17,49 @@ class Toolbar extends React.PureComponent {
     className: PropTypes.string,
     children: PropTypes.node,
     fixed: PropTypes.bool,
+    waterfall: PropTypes.bool,
+    flexible: PropTypes.bool,
+    fixedLastRowOnly: PropTypes.bool,
+    flexibleDefaultBehavior: PropTypes.bool,
+    onChange: PropTypes.func,
   }
 
   componentDidMount() {
+    this.toolbar = new MDCToolbar(this.node);
     if (this.props.fixed) {
-      const contentElements = document.getElementsByClassName('mdc-content');
-      Array.prototype.forEach.call(contentElements, (content) => {
-        content.classList.add(ADJUST);
-      });
+      this.toolbar.fixedAdjustElement = document.querySelector(`.${ROOT}-fixed-adjust`);
+    }
+    this.toolbar.listen('MDCToolbar:change', (e) => { this.handleMDCToolbarChange(e); });
+  }
+
+  componentWillReceiveProps() {
+    this.toolbar.fixedAdjustElement = document.querySelector(`.${ROOT}-fixed-adjust`);
+  }
+
+  componentWillUnmount() {
+    this.toolbar.unlisten('MDCToolbar:change', (e) => { this.handleMDCToolbarChange(e); });
+    this.toolbar.destroy();
+  }
+
+  handleMDCToolbarChange(e) {
+    if (this.props.onChange) {
+      this.props.onChange(e);
     }
   }
 
   render() {
-    const { className, fixed, children, ...otherProps } = this.props;
+    const { className, fixed, waterfall, fixedLastRowOnly, flexible, flexibleDefaultBehavior,
+      children, ...otherProps } = this.props;
+
     return (
       <header
+        ref={(node) => { this.node = node; }}
         className={classnames(ROOT, {
           [FIXED]: fixed,
+          [FIXED_LAST_ROW_ONLY]: fixedLastRowOnly,
+          [WATERFALL]: waterfall,
+          [FLEXIBLE]: flexible,
+          [FLEXIBLE_DEFAULT_BEHAVIOR]: flexibleDefaultBehavior,
         }, className)}
         {...otherProps}
       >

--- a/src/Toolbar/ToolbarIcon.js
+++ b/src/Toolbar/ToolbarIcon.js
@@ -1,0 +1,22 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+import classnames from 'classnames';
+
+const propTypes = {
+  className: PropTypes.string,
+  menu: PropTypes.bool,
+};
+
+const ToolbarIcon = ({
+  className,
+  menu,
+  ...otherProps
+}) => (
+  <i
+    className={classnames(menu ? 'mdc-toolbar__icon--menu' : 'mdc-toolbar__icon', className)}
+    {...otherProps}
+  />
+);
+ToolbarIcon.propTypes = propTypes;
+export default ToolbarIcon;
+

--- a/src/Toolbar/index.js
+++ b/src/Toolbar/index.js
@@ -2,3 +2,4 @@ export { default as Toolbar } from './Toolbar';
 export { default as ToolbarSection } from './ToolbarSection';
 export { default as ToolbarTitle } from './ToolbarTitle';
 export { default as ToolbarRow } from './ToolbarRow';
+export { default as ToolbarIcon } from './ToolbarIcon';

--- a/src/index.js
+++ b/src/index.js
@@ -12,7 +12,7 @@ export { default as Icon } from './Icon';
 export { Drawer, DrawerSpacer, Navigation, DrawerHeader, DrawerHeaderContent, DrawerContent } from './Drawer';
 export { Grid, Cell } from './Grid';
 export { default as Snackbar } from './Snackbar';
-export { Toolbar, ToolbarSection, ToolbarTitle, ToolbarRow } from './Toolbar';
+export { Toolbar, ToolbarSection, ToolbarTitle, ToolbarRow, ToolbarIcon } from './Toolbar';
 export { default as Content } from './Content';
 export { Radio, RadioGroup } from './Radio';
 export { Menu, MenuItem, MenuDivider, MenuAnchor } from './Menu';


### PR DESCRIPTION
- flexible
- waterfall
- waterfall with fixed last row

Also update the `Content` component to match MDC spec in how to specify
that it is being used with a fixed toolbar.

Update toolbar demo to show all the possibilities.