### PR TITLE
Fix case where `value` === "0"

### DIFF
--- a/src/Textfield/Label.js
+++ b/src/Textfield/Label.js
@@ -16,7 +16,7 @@ const Label = ({ focused, children, id, value }) => (
   <label
     className={classnames(
         ROOT, {
-          [LABEL_FLOAT_ABOVE]: focused || value,
+          [LABEL_FLOAT_ABOVE]: focused || String(value).length,
         },
       )}
     htmlFor={id}


### PR DESCRIPTION
The Textfield may be used to represent a numeric value; in the case where the value is the string "0", "0.0" or other falsey string values the label doesn't float like it should do.