### PR TITLE
Upgrade to mdc 0.23.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ npm i --save react-mdc-web
 ### Default theme
 * Include CSS with default theme into HTML page
   ```html
-  <link rel="stylesheet" href="https://unpkg.com/material-components-web@0.22.0/dist/material-components-web.min.css"> 
+  <link rel="stylesheet" href="https://unpkg.com/material-components-web@0.23.0/dist/material-components-web.min.css">
   ```
 * Or import it into JS/JSX file
   ```javascript

--- a/docs/components/Logo/Logo.js
+++ b/docs/components/Logo/Logo.js
@@ -2,12 +2,8 @@ import React from 'react';
 import logoUrl from './logo-white-30.svg';
 
 const Logo = () => (
-  <div
-    className="toolbar-logo"
-  >
     <img 
       src={logoUrl}
     />
-  </div>
 );
 export default Logo;

--- a/docs/components/Toolbar/Toolbar.js
+++ b/docs/components/Toolbar/Toolbar.js
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import classnames from 'classnames';
-import {Toolbar, ToolbarRow, ToolbarSection, ToolbarTitle} from '../../../src/Toolbar';
+import {Toolbar, ToolbarRow, ToolbarSection, ToolbarTitle, ToolbarIcon} from '../../../src/Toolbar';
 import { colors, activeColors } from 'utils/colors'
 import { Link } from 'react-router'
 import { prefixLink } from 'gatsby-helpers'
@@ -35,7 +35,9 @@ export default class AppToolbar extends React.Component {
           <ToolbarSection
             align="start"
           >
-            <Logo/>
+            <ToolbarIcon menu={true}>
+              <Logo/>
+            </ToolbarIcon>
             <ToolbarTitle style={{lineHeight: "36px"}}>
               <Link
                 to={prefixLink('/')}
@@ -49,16 +51,16 @@ export default class AppToolbar extends React.Component {
           <ToolbarSection
             align="end"
           >
-            <a
-              style={{
-                color: colors.fg,
-                textDecoration: 'none',
-                lineHeight: '36px',
-              }}
-              href="https://github.com/kradio3/react-mdc-web"
-            >
-              Github
-            </a>
+            <ToolbarIcon>
+              <a
+                style={{
+                  color: colors.fg,
+                }}
+                href="https://github.com/kradio3/react-mdc-web"
+              >
+                Github
+              </a>
+            </ToolbarIcon>
           </ToolbarSection>
         </ToolbarRow>
         {toolbarMode.fixedLastRowOnly &&

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
   },
   "dependencies": {
     "classnames": "^2.2.5",
-    "material-components-web": "^0.22.0",
+    "material-components-web": "^0.23.0",
     "prop-types": "^15.5.10"
   }
 }

--- a/src/Toolbar/ToolbarIcon.js
+++ b/src/Toolbar/ToolbarIcon.js
@@ -4,18 +4,22 @@ import classnames from 'classnames';
 
 const propTypes = {
   className: PropTypes.string,
+  children: PropTypes.node,
   menu: PropTypes.bool,
 };
 
 const ToolbarIcon = ({
   className,
+  children,
   menu,
   ...otherProps
 }) => (
-  <i
-    className={classnames(menu ? 'mdc-toolbar__icon--menu' : 'mdc-toolbar__icon', className)}
+  <span
+    className={classnames(menu ? 'mdc-toolbar__menu-icon' : 'mdc-toolbar__icon', className)}
     {...otherProps}
-  />
+  >
+    {children}
+  </span>
 );
 ToolbarIcon.propTypes = propTypes;
 export default ToolbarIcon;


### PR DESCRIPTION
- Fix breaking change of mdc-toolbar__icon--menu
  to mdc-toolbar__menu-icon
- Update demo to show the usage of ToolbarIcon