### PR TITLE
Create expansion panel components

### DIFF
--- a/docs/config.toml
+++ b/docs/config.toml
@@ -21,6 +21,9 @@ linkPrefix = "/react-mdc-web"
   name = "Elevation"
   path = "/components/elevation/"
 [[components]]
+  name = "Expansion Panel"
+  path = "/components/expansion_panel/"
+[[components]]
   name = "FAB"
   path = "/components/fab/"
 [[components]]

--- a/docs/pages/components/expansion_panel/_template.jsx
+++ b/docs/pages/components/expansion_panel/_template.jsx
@@ -1,0 +1,35 @@
+import React, {PropTypes} from 'react';
+import ReactDOM from 'react-dom';
+import {ExpansionPanel, Panel} from '../../../../src/ExpansionPanel';
+
+class Template extends React.PureComponent {
+
+  static propTypes = {
+    children: PropTypes.node,
+  };
+
+
+  componentDidMount() {
+    const container = document.getElementById('expansionPanels');
+    ReactDOM.render(this.renderExpansionPanels(), container);
+  }
+
+  renderExpansionPanels() {
+    return (
+        <ExpansionPanel >
+          <Panel title="Panel 1">First panel!</Panel>
+          <Panel title="Panel 2">Second panel!</Panel>
+          <Panel title="Panel 3">Third panel!</Panel>
+        </ExpansionPanel>
+    );
+  }
+
+  render() {
+    return (
+        <div>
+          {this.props.children}
+        </div>
+    );
+  }
+}
+export default Template;

--- a/docs/pages/components/expansion_panel/index.md
+++ b/docs/pages/components/expansion_panel/index.md
@@ -1,0 +1,14 @@
+---
+title: "Expansion Panels"
+---
+
+```react-snippet
+expansionPanels
+```
+```jsx
+<ExpansionPanel >
+    <Panel title="Panel 1">First panel!</Panel>
+    <Panel title="Panel 2">Second panel!</Panel>
+    <Panel title="Panel 3">Third panel!</Panel>
+</ExpansionPanel>
+```

--- a/src/ExpansionPanel/ExpansionPanel.js
+++ b/src/ExpansionPanel/ExpansionPanel.js
@@ -16,7 +16,8 @@ export default class ExpansionPanels extends React.Component {
     >
       <ul
           className={classnames(
-              'mdc-list'
+              'mdc-list',
+              this.props.className
           )}
           style={{
             padding: 0,

--- a/src/ExpansionPanel/ExpansionPanel.js
+++ b/src/ExpansionPanel/ExpansionPanel.js
@@ -1,0 +1,32 @@
+import React from 'react';
+import Elevation from '../Elevation/Elevation';
+import classnames from 'classnames';
+export default class ExpansionPanels extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      activePanel: !props.expandable
+    };
+  }
+
+  render() {
+
+    return <Elevation
+        z={4}
+    >
+      <ul
+          className={classnames(
+              'mdc-list'
+          )}
+          style={{
+            padding: 0,
+            margin: 0,
+            minWidth: '200px'
+          }}
+      >
+        {this.props.children}
+      </ul>
+    </Elevation>;
+  }
+}
+

--- a/src/ExpansionPanel/Panel.js
+++ b/src/ExpansionPanel/Panel.js
@@ -1,0 +1,65 @@
+import React from 'react';
+import classnames from 'classnames';
+
+import Icon from '../Icon/Icon';
+
+export default class Panel extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      expanded: false
+    };
+  }
+
+  onClick() {
+    this.setState({ expanded: !this.state.expanded });
+  }
+
+  renderExpanded() {
+    if (this.state.expanded) {
+      return <div>
+        {this.props.children}
+      </div>;
+    }
+  }
+
+  render() {
+    const listStyles = {
+      padding: '0 24px',
+      border: '1px solid rgba(0, 0, 0, .12)',
+      borderRadius: '2px',
+    };
+    const expandedStyle = {
+      paddingBottom: '16px',
+      ...listStyles
+    };
+    const collapsedStyle = {
+      ...listStyles
+    };
+    const expandedStyles = this.state.expanded ? expandedStyle : collapsedStyle;
+    return <li
+        key="li"
+        className={classnames(
+            { 'mdc-list-item': !this.state.expanded }
+        )}
+        style={expandedStyles}
+    >
+      <div
+          onClick={this.onClick.bind(this)}
+          className={classnames('mdc-list-item')}
+          style={{
+            width: '100%',
+            height: '48px'
+          }}
+      >
+        {this.props.title}
+        <Icon
+            name={this.state.expanded ? 'expand_less' : 'expand_more'}
+            className={classnames('mdc-list-item__end-detail')}
+        />
+      </div>
+
+      {this.renderExpanded()}
+    </li>;
+  }
+}

--- a/src/ExpansionPanel/Panel.js
+++ b/src/ExpansionPanel/Panel.js
@@ -1,9 +1,15 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import classnames from 'classnames';
 
 import Icon from '../Icon/Icon';
 
 export default class Panel extends React.Component {
+  static propTypes = {
+    children: PropTypes.node,
+    title: PropTypes.string,
+  };
+
   constructor(props) {
     super(props);
     this.state = {
@@ -40,7 +46,8 @@ export default class Panel extends React.Component {
     return <li
         key="li"
         className={classnames(
-            { 'mdc-list-item': !this.state.expanded }
+            { 'mdc-list-item': !this.state.expanded },
+            this.props.className
         )}
         style={expandedStyles}
     >

--- a/src/ExpansionPanel/index.js
+++ b/src/ExpansionPanel/index.js
@@ -1,0 +1,2 @@
+export { default as ExpansionPanel } from './ExpansionPanel';
+export { default as Panel } from './Panel';


### PR DESCRIPTION
- [x] props checks
- [ ] Expansion Panel needs [focused state](https://material.io/guidelines/components/expansion-panels.html#expansion-panels-behavior)
- [ ] Would be nice if opening one expansion panel closed the others, might be worth investigating with focused state.