### PR TITLE
Include /src in build; Set side effects to false

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,4 +1,3 @@
-src/
 docs/
 node_modules/
 tmp_docs/

--- a/package.json
+++ b/package.json
@@ -51,7 +51,8 @@
     "LICENSE.md",
     "README.md",
     "lib/",
-    "out/"
+    "out/",
+    "src/"
   ],
   "scripts": {
     "preversion": "npm test",

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "React web components for Material Design",
   "main": "lib/index.js",
   "jsnext:main": "src/index.js",
+  "side-effects": false,
   "author": "kradio3",
   "license": "SEE LICENSE IN LICENSE.md",
   "repository": "kradio3/react-mdc-web",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "React web components for Material Design",
   "main": "lib/index.js",
   "jsnext:main": "src/index.js",
-  "side-effects": false,
+  "sideEffects": false,
   "author": "kradio3",
   "license": "SEE LICENSE IN LICENSE.md",
   "repository": "kradio3/react-mdc-web",


### PR DESCRIPTION
This is an attempt to make smaller builds with webpack by using usual named exports, without transforming the imports into `react-mdc-web/lib/x`.

At current master `jsnext:main` in package.json points to nowhere.