### PR TITLE
Allow menu items to be dynamically added

### DIFF
--- a/src/Menu/DelayedItems.js
+++ b/src/Menu/DelayedItems.js
@@ -20,7 +20,7 @@ const DelayedItems = WrappedComponent => class extends React.PureComponent {
     const { applyDelays, children } = this.props;
     const isEqualChildren = () => {
       if (children.length !== nextChildren.length) {
-        return false
+        return false;
       }
       let i = children.length;
       if (i != nextChildren.length) return false;
@@ -34,7 +34,7 @@ const DelayedItems = WrappedComponent => class extends React.PureComponent {
         children: nextApplyDelays ? this.applyTransitionDelays() : children,
       });
     } else if (!isEqualChildren()) {
-      this.setState({children: nextChildren})
+      this.setState({children: nextChildren});
     }
   }
 

--- a/src/Menu/DelayedItems.js
+++ b/src/Menu/DelayedItems.js
@@ -16,12 +16,25 @@ const DelayedItems = WrappedComponent => class extends React.PureComponent {
     this.state = { children };
   }
 
-  componentWillReceiveProps({ applyDelays: nextApplyDelays }) {
+  componentWillReceiveProps({ applyDelays: nextApplyDelays, children: nextChildren }) {
     const { applyDelays, children } = this.props;
+    const isEqualChildren = () => {
+      if (children.length !== nextChildren.length) {
+        return false
+      }
+      let i = children.length;
+      if (i != nextChildren.length) return false;
+      while (i--) {
+        if (children[i] !== nextChildren[i]) return false;
+      }
+      return true;
+    }
     if (applyDelays !== nextApplyDelays) {
       this.setState({
         children: nextApplyDelays ? this.applyTransitionDelays() : children,
       });
+    } else if (!isEqualChildren()) {
+      this.setState({children: nextChildren})
     }
   }
 

--- a/src/Menu/DelayedItems.js
+++ b/src/Menu/DelayedItems.js
@@ -25,7 +25,7 @@ const DelayedItems = WrappedComponent => class extends React.PureComponent {
       let i = children.length;
       if (i !== nextChildren.length) return false;
       while (i > 0) {
-        i = i - 1;
+        i -= 1;
         if (children[i] !== nextChildren[i]) return false;
       }
       return true;

--- a/src/Menu/DelayedItems.js
+++ b/src/Menu/DelayedItems.js
@@ -23,18 +23,19 @@ const DelayedItems = WrappedComponent => class extends React.PureComponent {
         return false;
       }
       let i = children.length;
-      if (i != nextChildren.length) return false;
-      while (i--) {
+      if (i !== nextChildren.length) return false;
+      while (i > 0) {
+        i = i - 1;
         if (children[i] !== nextChildren[i]) return false;
       }
       return true;
-    }
+    };
     if (applyDelays !== nextApplyDelays) {
       this.setState({
         children: nextApplyDelays ? this.applyTransitionDelays() : children,
       });
     } else if (!isEqualChildren()) {
-      this.setState({children: nextChildren});
+      this.setState({ children: nextChildren });
     }
   }
 


### PR DESCRIPTION
Right now menu items won't be updated if we add them after menu has been opened. This PR fixes it by checking if nextChildren has changed.