### PR TITLE
fix(DrawerContent.js): Temporary should be a string value

### DIFF
--- a/src/Drawer/DrawerContent.js
+++ b/src/Drawer/DrawerContent.js
@@ -9,7 +9,7 @@ const propTypes = {
 };
 
 const DrawerContent = ({ className, children, temporary, ...otherProps }) => {
-  const childs = React.Children.map(children, child => React.cloneElement(child, { temporary }));
+  const childs = React.Children.map(children, child => React.cloneElement(child, { temporary: temporary.toString() }));
   return (
     <div
       className={classnames(


### PR DESCRIPTION
Parse boolean to string, this removes an warning error that triggers when using a drawer and should be the right implementation.

Thanks @kradio3 